### PR TITLE
Add section header to the form

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -19,28 +19,23 @@ import { styles } from '../styles';
 const formFields: FormField[] = [
     {
         name: 'persona',
-        description: `"Know You, the Prompt Creator!"
-Pick who you are prompting for, "as a 1st year university student, specialising in Jane Austen's novels" or "as a wheel-chair user grandparent looking for fun travel ideas with grandchildren"`,
+        description: '',
     },
     {
         name: 'context',
-        description: `"Set the Scene!"
-Give a quick backdrop "I intend to gather relevant quotes for a presentation for my Indian clients in manufacturing" or "I intend to search for easy, nutritious recipes for my picky eaters."`,
+        description: '',
     },
     {
         name: 'task',
-        description: `"What's the Mission?"
-State your goal  " Recommend must-read books on Italian architecture" or "List family-friendly events in Stockholm this weekend."`,
+        description: '',
     },
     {
         name: 'output',
-        description: `"How?"
-Tell how you want the answer delivered: an essay, a bullet-point list, a brief summary, or step-by-step tips and the tone: professional, informal..`,
+        description: '',
     },
     {
         name: 'constraint',
-        description: `"Keep It Tight!"
-Set the boundaries: "US based only", "In British English", "no hyphenation", "Avoid complex jargon", or "In three words"...`,
+        description: '',
     },
 ];
 
@@ -60,94 +55,117 @@ const Form = ({ onFormSubmit }: FormComponentProps) => {
         setValue(field.name, '');
     };
     return (
-        <Box
-            component="section"
-            sx={{
-                ...styles.flexColumn,
-                justifyContent: 'space-between',
-                ...styles.displayContainer,
-                padding: 2,
-            }}
-        >
-            <form onSubmit={handleSubmit(onSubmit)}>
-                {formFields.map((field) => (
-                    <>
-                        <span
-                            style={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '4px',
-                                marginLeft: 20,
-                            }}
-                        >
-                            <Typography
-                                sx={{
-                                    color: styles.colors.fontPrimary,
+        <Box component="section" sx={{ marginTop: '4em' }}>
+            <Typography
+                variant="h4"
+                sx={{
+                    fontSize: styles.typography.fontSizeLarge,
+                    fontWeight: 600,
+                    marginBottom: '0.75em',
+                }}
+            >
+                Pentagram it
+            </Typography>
+            <Typography sx={{ fontSize: styles.typography.fontSizeNormal }}>
+                Remember to fill in ideas for all 5 prompts
+            </Typography>
+            <Typography sx={{ fontSize: styles.typography.fontSizeNormal }}>
+                to generate an answer.
+            </Typography>
+            <Box
+                component="section"
+                sx={{
+                    ...styles.flexColumn,
+                    justifyContent: 'space-between',
+                    ...styles.container,
+                    padding: '1.5em 1em',
+                    marginTop: '2em',
+                }}
+            >
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    {formFields.map((field) => (
+                        <>
+                            <span
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: '4px',
                                 }}
                             >
-                                {capitalise(field.name)}
-                            </Typography>
-                            <Tooltip title={field.description}>
-                                <IconButton
+                                <Typography
                                     sx={{
                                         color: styles.colors.fontPrimary,
                                     }}
                                 >
-                                    <HelpOutlineIcon />
-                                </IconButton>
-                            </Tooltip>
-                        </span>
+                                    {capitalise(field.name)}
+                                </Typography>
+                                <Tooltip
+                                    title={field.description}
+                                    id={field.name + 'tooltip'}
+                                    role="tooltip"
+                                >
+                                    <IconButton
+                                        sx={{
+                                            color: styles.colors.fontPrimary,
+                                        }}
+                                    >
+                                        <HelpOutlineIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </span>
 
-                        <TextField
-                            key={field.name}
-                            id={field.name}
-                            variant="outlined"
-                            {...register(field.name, {
-                                required: true,
-                            })}
-                            error={!!errors[field.name]}
-                            sx={styles.textField}
-                            multiline
-                            rows={5}
-                            slotProps={{
-                                input: {
-                                    placeholder: field.description,
-                                    endAdornment: (
-                                        <InputAdornment position="end">
-                                            <ClearIcon
-                                                onClick={() =>
-                                                    clearField(field)
-                                                }
-                                                sx={{
-                                                    color: styles.colors
-                                                        .fontPrimary,
-                                                }}
-                                                className="clear-icon"
-                                            />
-                                        </InputAdornment>
-                                    ),
-                                },
-                            }}
-                        />
-                        {errors[field.name] && (
-                            <Typography
-                                color="error"
-                                variant="caption"
-                                sx={{ ml: 2 }}
-                            >
-                                {errors[field.name]?.message}
-                            </Typography>
-                        )}
-                    </>
-                ))}
-                <Button
-                    variant="contained"
-                    type="submit"
-                    sx={{ ...styles.primaryButton }}
-                >
-                    Generate
-                </Button>
-            </form>
+                            <TextField
+                                key={field.name}
+                                id={field.name}
+                                aria-describedby={field.name + 'tooltip'}
+                                variant="outlined"
+                                {...register(field.name, {
+                                    required: true,
+                                })}
+                                error={!!errors[field.name]}
+                                sx={{ ...styles.textField }}
+                                multiline
+                                rows={5}
+                                slotProps={{
+                                    input: {
+                                        placeholder: field.description,
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <ClearIcon
+                                                    onClick={() =>
+                                                        clearField(field)
+                                                    }
+                                                    sx={{
+                                                        color: styles.colors
+                                                            .fontPrimary,
+                                                    }}
+                                                    className="clear-icon"
+                                                />
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                            {errors[field.name] && (
+                                <Typography
+                                    color="error"
+                                    variant="caption"
+                                    sx={{ ml: 2 }}
+                                >
+                                    {errors[field.name]?.message}
+                                </Typography>
+                            )}
+                        </>
+                    ))}
+                    <Button
+                        variant="contained"
+                        type="submit"
+                        sx={{ ...styles.primaryButton }}
+                    >
+                        Generate
+                    </Button>
+                </form>
+            </Box>
         </Box>
     );
 };

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -13,7 +13,8 @@ const Prompt = ({ prompt, onPromptSubmit }: PromptProps) => {
             sx={{
                 ...styles.flexColumn,
                 justifyContent: 'space-between',
-                ...styles.displayContainer,
+                ...styles.container,
+                ...styles.promptContainer,
             }}
         >
             {prompt ? (

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -14,7 +14,7 @@ const Result = ({ result, loading }: ResultProps) => {
         <Box
             component="section"
             sx={{
-                ...styles.displayContainer,
+                ...styles.container,
                 p: 2,
             }}
         >

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,20 +2,26 @@ export const styles = {
     typography: {
         fontSizeExtraSmall: '8px',
         fontSizeSmall: '10px',
+        fontSizeNormal: '13px',
+        fontSizeLarge: '35px',
     },
     colors: {
         footerBackground: '#12141D',
         fontPrimary: '#FFFFFF',
         fontSecondary: '#CBC9C9',
     },
-    displayContainer: {
+    container: {
         width: '100%',
         minHeight: '250px',
-        border: '3px solid transparent',
-        background:
-            'linear-gradient(#313342, #313342) padding-box, linear-gradient(to right, #8A00F9 0%, #FD99FF 100%) border-box',
         borderRadius: '8px',
         marginBottom: '4em',
+        border: '2px solid #CBC9C9',
+        backgroundColor: '#313342',
+    },
+    promptContainer: {
+        border: '2px solid transparent',
+        background:
+            'linear-gradient(#313342, #313342) padding-box, linear-gradient(to right, #8A00F9 0%, #FD99FF 100%) border-box',
     },
     flexRow: {
         display: 'flex',
@@ -34,7 +40,9 @@ export const styles = {
         borderRadius: '15px',
     },
     textField: {
-        backgroundColor: 'transparent',
+        backgroundColor: '#595959',
+        marginBottom: '1.5em',
+        borderRadius: '8px',
         '& label': { color: '#FFFFFF' }, // we're not displaying label currently
         '& .MuiOutlinedInput-root': {
             color: '#FFFFFF',


### PR DESCRIPTION
There is now a header for the form telling the user to Pentagram it and accompanying text.

I also added aria-describedby and that should tell the screen readers there are tool tips for the fields.

Only the prompt box should have the purple/pink border so removed it from the other containers.

Also changed the background of the text areas to match the forms and make it a better contrast.

Also removed the helper text for now until we have the shortened format.
