### PR TITLE
Add start button functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import showdown from 'showdown';
 import Hero from './components/Hero';
 import HowToUse from './components/HowToUse';
+import { useRef } from 'react';
 
 function App() {
     const [prompt, setPrompt] = useState<string>('');
@@ -22,6 +23,11 @@ function App() {
             fontFamily: `"Poppins", sans-serif`,
         },
     });
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleFocus = () => {
+        inputRef.current?.focus();
+    };
 
     function onFormSubmit(formData: Inputs) {
         const prompt = Object.values(formData)
@@ -75,10 +81,10 @@ function App() {
                 }}
             >
                 <Header />
-                <Hero />
+                <Hero onFocusInput={handleFocus} />
                 <HowToUse />
                 <Container sx={{ display: 'flex', flexDirection: 'column' }}>
-                    <Form onFormSubmit={onFormSubmit} />
+                    <Form onFormSubmit={onFormSubmit} ref={inputRef} />
                     <Prompt prompt={prompt} onPromptSubmit={onPromptSubmit} />
                     <Result result={result} loading={loading} />
                 </Container>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -44,7 +44,7 @@ Set the boundaries: "US based only", "In British English", "no hyphenation", "Av
     },
 ];
 
-const Form = ({ onFormSubmit }: FormComponentProps) => {
+const Form = ({ onFormSubmit, ref }: FormComponentProps) => {
     const {
         register,
         handleSubmit,
@@ -60,6 +60,7 @@ const Form = ({ onFormSubmit }: FormComponentProps) => {
         setValue(field.name, '');
         document.getElementById(field.name)?.focus();
     };
+
     return (
         <Box component="section" sx={{ marginTop: '4em' }}>
             <Typography
@@ -89,7 +90,7 @@ const Form = ({ onFormSubmit }: FormComponentProps) => {
                 }}
             >
                 <form onSubmit={handleSubmit(onSubmit)}>
-                    {formFields.map((field) => (
+                    {formFields.map((field, index) => (
                         <>
                             <span
                                 style={{
@@ -154,6 +155,8 @@ const Form = ({ onFormSubmit }: FormComponentProps) => {
                                         ),
                                     },
                                 }}
+                                inputRef={index === 0 ? ref : null}
+                                tabIndex={0}
                             />
                             {errors[field.name] && (
                                 <Typography

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { styles } from '../styles';
 
-const Hero = () => {
+const Hero = ({ onFocusInput }: { onFocusInput: () => void }) => {
     return (
         <Box
             component="section"
@@ -49,13 +49,14 @@ const Hero = () => {
                 Prompting,
             </Typography>
             <Typography>One Powerful AI Result</Typography>
-            {/* <Button
+            <Button
                 variant="contained"
                 type="button"
                 sx={{ ...styles.primaryButton, margin: '1em' }}
+                onClick={onFocusInput}
             >
                 Start now
-            </Button> */}
+            </Button>
             <Typography sx={{ fontSize: styles.typography.fontSizeNormal }}>
                 Try it, it's free
             </Typography>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { inputFormSchema } from './assets/inputFormSchema';
+import { RefObject } from 'react';
 
 export type Inputs = z.infer<typeof inputFormSchema>;
 
@@ -10,6 +11,7 @@ export type FormField = {
 
 export type FormComponentProps = {
     onFormSubmit: (data: Inputs) => void;
+    ref: RefObject<HTMLInputElement | null>;
 };
 
 export type TeamMembers = {


### PR DESCRIPTION
The app defines a useRef and it is intially null. When the form component loads and it assigns the useRef passed down to one of the input fields, the useRef in the parent now has a pointer to that.

So when the button is clicked in the Hero component and it runs a function in the parent it can now apply focus to the element in the form.